### PR TITLE
Agrega validación de parámetros para copias

### DIFF
--- a/src/middlewares/validate-copy-data.js
+++ b/src/middlewares/validate-copy-data.js
@@ -1,0 +1,24 @@
+// Middleware para validar parámetros de ruta y body en las rutas de copias
+// Se usa para asegurar que los datos recibidos sean del tipo y formato esperado antes de llegar al controlador
+
+export const validateCopyData = (req, res, next) => {
+  const { id, bookId } = req.params;
+  const { estado } = req.body;
+
+  // Validar que id y bookId sean numéricos si existen
+  // Esto previene errores en la base de datos y asegura que los controladores reciban datos válidos
+  if (id && !/^[0-9]+$/.test(id)) {
+    return res.status(400).json({ message: "El id debe ser numérico" });
+  }
+  if (bookId && !/^[0-9]+$/.test(bookId)) {
+    return res.status(400).json({ message: "El bookId debe ser numérico" });
+  }
+
+  // Validar campo de body (ejemplo: estado debe ser string si existe)
+  // Esto ayuda a evitar errores de validación en la lógica de negocio
+  if (estado && typeof estado !== "string") {
+    return res.status(400).json({ message: "El estado debe ser un string" });
+  }
+
+  next();
+};

--- a/src/routes/copy-router.js
+++ b/src/routes/copy-router.js
@@ -1,13 +1,16 @@
 import express from 'express';
 import { copyControllers } from '../controllers/index.js';
+import { validateCopyData } from '../middlewares/validate-copy-data.js'; // Importamos el middleware de validación
 
 const router = express.Router();
 
-router.get('/book/:bookId', copyControllers.getByBook);
-router.get('/available/:bookId', copyControllers.getAvailableCopies);
-router.get('/:id', copyControllers.getById);
-router.post('/', copyControllers.create);
-router.put('/:id', copyControllers.update);
-router.delete('/:id', copyControllers.delete);
+// Se aplica el middleware validateCopyData antes de cada controlador relevante
+// Esto asegura que los parámetros de ruta y body sean correctos antes de ejecutar la lógica del controlador
+router.get('/book/:bookId', validateCopyData, copyControllers.getByBook);
+router.get('/available/:bookId', validateCopyData, copyControllers.getAvailableCopies);
+router.get('/:id', validateCopyData, copyControllers.getById);
+router.post('/', validateCopyData, copyControllers.create);
+router.put('/:id', validateCopyData, copyControllers.update);
+router.delete('/:id', validateCopyData, copyControllers.delete);
 
 export default router;


### PR DESCRIPTION

- Se implementó el middleware `validateCopyData` en validate-copy-data.js para validar los parámetros de ruta (`id`, `bookId`) y el campo `estado` del body en las rutas de copias.
- Se aplicó este middleware en todas las rutas de copy-router.js.
- Esto asegura que los datos recibidos sean del tipo y formato esperado antes de llegar al controlador

Por favor revisar 