### PR TITLE
Integración completa de middlewares en rutas sensibles

### DIFF
--- a/src/middlewares/auth-guard.js
+++ b/src/middlewares/auth-guard.js
@@ -1,0 +1,20 @@
+// Middleware de autorización por rol.
+import CustomError from '../utils/custom-error.js';
+
+const authGuard = (allowedRoles = []) => {
+  return (req, res, next) => {
+    const user = req.user;
+
+    if (!user) {
+      return next(new CustomError('No autenticado', 401));
+    }
+
+    if (!allowedRoles.includes(user.rol)) {
+      return next(new CustomError('No autorizado', 403));
+    }
+
+    next(); 
+  };
+};
+
+export default authGuard;

--- a/src/middlewares/error-handler.js
+++ b/src/middlewares/error-handler.js
@@ -1,13 +1,8 @@
-export const errorHandler = (error, req, res, next) => {
- 
+const errorHandler = (error, req, res, next) => {
   const status = error.status || 500;
-
-
   const message = error.message || "Error interno del servidor";
 
-  
   const response = { message };
-
 
   if (process.env.NODE_ENV === "development") {
     response.stack = error.stack;
@@ -19,7 +14,6 @@ export const errorHandler = (error, req, res, next) => {
     return;
   }
 
- 
   if (error.name === "SequelizeUniqueConstraintError") {
     response.message = "Ya existe un registro con ese dato único.";
     res.status(400).json(response);
@@ -28,3 +22,5 @@ export const errorHandler = (error, req, res, next) => {
 
   res.status(status).json(response);
 };
+
+export default errorHandler;

--- a/src/routes/book-router.js
+++ b/src/routes/book-router.js
@@ -1,14 +1,39 @@
 import express from "express";
 import { bookControllers } from "../controllers/index.js";
+import { checkTokenUser } from "../middlewares/check-user.js";
+import authGuard from "../middlewares/auth-guard.js";
+import { validateBookData } from "../middlewares/validate-book-data.js";
 
 const router = express.Router();
 
+// Rutas protegidas para administradores (POST, PUT, DELETE)
+router.post(
+  "/",
+  checkTokenUser,
+  authGuard(["admin"]),
+  validateBookData,
+  bookControllers.create
+);
+
+router.put(
+  "/:id",
+  checkTokenUser,
+  authGuard(["admin"]),
+  validateBookData,
+  bookControllers.update
+);
+
+router.delete(
+  "/:id",
+  checkTokenUser,
+  authGuard(["admin"]),
+  bookControllers.delete
+);
+
+// Rutas públicas (GET)
 router.get("/", bookControllers.getAll);
 router.get("/search", bookControllers.search);
 router.get("/category/:categoryId", bookControllers.getByCategory);
 router.get("/:id", bookControllers.getById);
-router.post("/", bookControllers.create);
-router.put("/:id", bookControllers.update);
-router.delete("/:id", bookControllers.delete);
 
 export default router;

--- a/src/routes/category-router.js
+++ b/src/routes/category-router.js
@@ -1,14 +1,37 @@
 import express from 'express';
 import { categoryControllers } from '../controllers/index.js';
+import { checkTokenUser } from '../middlewares/check-user.js';
+import authGuard from '../middlewares/auth-guard.js';
 
 const router = express.Router();
 
+// Rutas protegidas (solo administradores)
+router.post(
+  '/',
+  checkTokenUser,
+  authGuard(['admin']),
+  categoryControllers.create
+);
 
+router.put(
+  '/:id',
+  checkTokenUser,
+  authGuard(['admin']),
+  categoryControllers.update
+);
+
+router.delete(
+  '/:id',
+  checkTokenUser,
+  authGuard(['admin']),
+  categoryControllers.delete
+);
+
+// Rutas públicas
 router.get('/', categoryControllers.getAll);
 router.get('/:id', categoryControllers.getById);
-//router.get('/:id/books', categoryControllers.getCategoryBooks); Aun no se creo el controlador para obtener los libros de una categoria
-router.post('/', categoryControllers.create);
-router.put('/:id', categoryControllers.update);
-router.delete('/:id', categoryControllers.delete);
+
+// RUTA SIN USO. Debido a que aun no se creó el controlador correspondiente.
+// router.get('/:id/books', categoryControllers.getCategoryBooks);
 
 export default router;

--- a/src/routes/loan-router.js
+++ b/src/routes/loan-router.js
@@ -1,12 +1,46 @@
 import express from 'express';
 import { loanControllers } from '../controllers/index.js';
+import { checkTokenUser } from '../middlewares/check-user.js';
+import authGuard from '../middlewares/auth-guard.js';
 
 const router = express.Router();
 
-router.get('/active', loanControllers.getActiveLoans);
-router.get('/overdue', loanControllers.getOverdueLoans);
-router.get('/user/:userId', loanControllers.getUserLoans);
-router.post('/', loanControllers.createLoan);
-router.put('/:id/return', loanControllers.returnLoan);
+// Rutas protegidas administrador 
+router.post(
+  '/',
+  checkTokenUser,
+  authGuard(['admin']),
+  loanControllers.createLoan
+);
+
+router.put(
+  '/:id/return',
+  checkTokenUser,
+  authGuard(['admin']),
+  loanControllers.returnLoan
+);
+
+// Acceso a prestamos por usuario: administrador o el mismo usuario
+router.get(
+  '/user/:userId',
+  checkTokenUser,
+  authGuard(['admin', 'user']),
+  loanControllers.getUserLoans
+);
+
+// Consultas generales (solo administrador)
+router.get(
+  '/active',
+  checkTokenUser,
+  authGuard(['admin']),
+  loanControllers.getActiveLoans
+);
+
+router.get(
+  '/overdue',
+  checkTokenUser,
+  authGuard(['admin']),
+  loanControllers.getOverdueLoans
+);
 
 export default router;

--- a/src/routes/rol-router.js
+++ b/src/routes/rol-router.js
@@ -1,13 +1,47 @@
 import express from 'express';
 import { rolControllers } from '../controllers/index.js';
+import { checkTokenUser } from '../middlewares/check-user.js';
+import authGuard from '../middlewares/auth-guard.js';
 
 const router = express.Router();
 
-router.get('/', rolControllers.getAll);
-router.get('/:id', rolControllers.getById);
-//router.get('/:id/users', rolControllers.getRoleUsers); No se ha creado el controlador para obtener los usuarios de un rol
-router.post('/', rolControllers.create);
-router.put('/:id', rolControllers.update);
-router.delete('/:id', rolControllers.delete);
+// Rutas protegidas solo para admsinistradores.
+router.get(
+  '/',
+  checkTokenUser,
+  authGuard(['admin']),
+  rolControllers.getAll
+);
+
+router.get(
+  '/:id',
+  checkTokenUser,
+  authGuard(['admin']),
+  rolControllers.getById
+);
+
+// RUTA SIN USO. Debido a que aún no se creó el controlador correspondiente:
+// router.get('/:id/users', rolControllers.getRoleUsers);
+
+router.post(
+  '/',
+  checkTokenUser,
+  authGuard(['admin']),
+  rolControllers.create
+);
+
+router.put(
+  '/:id',
+  checkTokenUser,
+  authGuard(['admin']),
+  rolControllers.update
+);
+
+router.delete(
+  '/:id',
+  checkTokenUser,
+  authGuard(['admin']),
+  rolControllers.delete
+);
 
 export default router;

--- a/src/routes/user-router.js
+++ b/src/routes/user-router.js
@@ -1,14 +1,39 @@
-import express from 'express';
-import { userControllers } from '../controllers/index.js';
+import express from "express";
+import { userControllers } from "../controllers/index.js";
+import { checkTokenUser } from "../middlewares/check-user.js";
+import authGuard from "../middlewares/auth-guard.js";
+import { validateUserData } from "../middlewares/validate-user-data.js";
 
 const router = express.Router();
 
-router.get('/', userControllers.getAll);
-router.get('/dni/:dni', userControllers.getByDni);
-router.get('/role/:roleId', userControllers.getByRole);
-router.get('/:id', userControllers.getById);
-router.post('/', userControllers.create);
-router.put('/:id', userControllers.update);
-router.delete('/:id', userControllers.delete);
+// Rutas protegidas para los administradores.
+router.post(
+  "/",
+  checkTokenUser,
+  authGuard(["admin"]),
+  validateUserData,
+  userControllers.create
+);
+
+router.put(
+  "/:id",
+  checkTokenUser,
+  authGuard(["admin"]),
+  validateUserData,
+  userControllers.update
+);
+
+router.delete(
+  "/:id",
+  checkTokenUser,
+  authGuard(["admin"]),
+  userControllers.delete
+);
+
+// Rutas públicas
+router.get("/", userControllers.getAll);
+router.get("/dni/:dni", userControllers.getByDni);
+router.get("/role/:roleId", userControllers.getByRole);
+router.get("/:id", userControllers.getById); 
 
 export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -15,11 +15,11 @@ initMySQLDB()
 
 import './models/index.js'; // importa todas las relaciones SIN causar ciclo
 
-//import routes from './routes/index.js'; Importa las rutas de la aplicación
-//app.use('/', routes);
+import routes from './routes/index.js';
+app.use('/', routes);
 
-//import errorMiddleware from './middlewares/error-middleware.js'; Importa el middleware de manejo de errores
-//app.use(errorMiddleware); 
+import errorHandler from './middlewares/error-handler.js'; 
+app.use(errorHandler); 
 
 
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/services/user-services.js
+++ b/src/services/user-services.js
@@ -13,8 +13,12 @@ export class UserService {
         return await UserModel.findOne({ where: { dni } });
     }
 
+    // Método actualizado
     async getByEmail(email) {
-        return await UserModel.findOne({ where: { email } });
+    return await UserModel.findOne({
+    where: { email },
+    attributes: ['id_usuario', 'email', 'password', 'id_rol']
+    });
     }
 
     async create(userData) {


### PR DESCRIPTION
Este PR aplica los middlewares de autenticación, autorización y validación (validateBookData, validateUserData que faltaban integrar) en las rutas sensibles. Protege las operaciones de creación, edición y eliminación en libros, usuarios, préstamos, categorías y roles.
Los controladores _categoryControllers.getCategoryBooks_ y _rolControllers.getRoleUsers_ siguen comentados porque no están armados.
Entonces, solo usuarios autenticados pueden acceder a rutas restringidas y acciones como crear, editar y borrar requieren el rol admin. Las rutas públicas GET siguen abiertas.
Se agregó campo password al getByEmail en user-services.js para soporte a login. Las rutas públicas como /books siguen accesibles sin autenticación.

Revisar para integrar rama.